### PR TITLE
Remove auto enabling scriptblock logging - Fixes #6

### DIFF
--- a/DSCClassResources/JeaSessionConfiguration/JeaSessionConfiguration.psm1
+++ b/DSCClassResources/JeaSessionConfiguration/JeaSessionConfiguration.psm1
@@ -308,15 +308,6 @@ class JeaSessionConfiguration
                 ## Register the configuration file
                 $this.RegisterPSSessionConfiguration($this.EndpointName, $psscPath, $this.HungRegistrationTimeout)
 
-                ## Enable PowerShell logging on the system
-                $basePath = "HKLM:\Software\Policies\Microsoft\Windows\PowerShell\ScriptBlockLogging"
-
-                if (-not (Test-Path $basePath))
-                {
-                    $null = New-Item $basePath -Force
-                }
-
-                Set-ItemProperty $basePath -Name EnableScriptBlockLogging -Value "1"
             }
         }
         finally


### PR DESCRIPTION
Automatically enabling scriptblock logging shouldn't be part of this module. It's not required by JEA but is a very nice thing to have, therefore it should be up to the person creating the configuration to handle that.