### PR TITLE
Fix roles modules - Fixes #12

### DIFF
--- a/DSCClassResources/JeaRoleCapabilities/JeaRoleCapabilities.psm1
+++ b/DSCClassResources/JeaRoleCapabilities/JeaRoleCapabilities.psm1
@@ -173,28 +173,40 @@ class JeaRoleCapabilities {
  }
 
 function Convert-StringToObject {
+    [cmdletbinding()]
     param (
         [string]$InputString
     )
 
-    if ($InputString -match ',') {
-        $ast = [System.Management.Automation.Language.Parser]::ParseInput($InputString, [ref] $null, [ref] $null)
-        $Data = $ast.Find( { $args[0] -is [System.Management.Automation.Language.ArrayLiteralAst] }, $false )
-        foreach ($Element in $Data.Elements){
-            if ($Element.StaticType.Name -eq 'String'){
-                $Element.value
-            }
-            if ($Element.StaticType.Name -eq 'Hashtable'){
-                [Hashtable]$Element.SafeGetValue()
+    $ParseErrors = @()
+    $FakeCommand = "Totally-NotACmdlet -FakeParameter $InputString"
+    $AST = [System.Management.Automation.Language.Parser]::ParseInput($FakeCommand,[ref]$null,[ref]$ParseErrors)
+    if(-not $ParseErrors){
+        # Use Ast.Find() to locate the CommandAst parsed from our fake command
+        $CmdAst = $AST.Find({param($ChildAst) $ChildAst -is [System.Management.Automation.Language.CommandAst]},$false)
+        # Grab the user-supplied arguments (index 0 is the command name, 1 is our fake parameter)
+        $ArgumentAst = $CmdAst.CommandElements[2]
+        if($ArgumentAst -is [System.Management.Automation.Language.ArrayLiteralAst]) {
+            # Argument was a list
+            foreach ($Element in $ArgumentAst.Elements){
+                if ($Element.StaticType.Name -eq 'String'){
+                    $Element.value
+                }
+                if ($Element.StaticType.Name -eq 'Hashtable'){
+                    [Hashtable]$Element.SafeGetValue()
+                }
             }
         }
-    }
-    elseif ($InputString -match '@{') {
-        $ast = [System.Management.Automation.Language.Parser]::ParseInput($InputString, [ref] $null, [ref] $null)
-        $Data = $ast.Find( { $args[0] -is [System.Management.Automation.Language.HashtableAst] }, $false )
-        [Hashtable]$Data.SafeGetValue()
-    }
-    else {
-        $InputString
+        else {
+            if ($ArgumentAst -is [System.Management.Automation.Language.HashtableAst]) {
+                [Hashtable]$ArgumentAst.SafeGetValue()
+            }
+            elseif ($ArgumentAst -is [System.Management.Automation.Language.StringConstantExpressionAst]) {
+                $InputString
+            }
+            else {
+                Write-Error -Message "Input was not a valid hashtable, string or collection of both. Please check the contents and try again."
+            }
+        }
     }
 }

--- a/DSCClassResources/JeaRoleCapabilities/JeaRoleCapabilities.psm1
+++ b/DSCClassResources/JeaRoleCapabilities/JeaRoleCapabilities.psm1
@@ -171,3 +171,20 @@ class JeaRoleCapabilities {
         return $false
     }
  }
+
+ function Convert-StringToObject {
+     param (
+         [string]$InputString
+     )
+
+    $ast = [System.Management.Automation.Language.Parser]::ParseInput($InputString, [ref] $null, [ref] $null)
+    $Data = $ast.Find( { $args[0] -is [System.Management.Automation.Language.ArrayLiteralAst] }, $false )
+    foreach ($Element in $Data.Elements){
+        if ($Element.StaticType.Name -eq 'String'){
+            $Element.value
+        }
+        if ($Element.StaticType.Name -eq 'Hashtable'){
+            [Hashtable]$Element.SafeGetValue()
+        }
+    }
+ }

--- a/Tests/Unit/JeaRoleCapabilities.Tests.ps1
+++ b/Tests/Unit/JeaRoleCapabilities.Tests.ps1
@@ -29,7 +29,7 @@ Describe "Testing JeaRoleCapabilities" {
             }
 
             It "Should return a single string when passed only one cmdlet" {
-                $Output = Convert-StringToObject -InputString "'Invoke-Cmdlet'"
+                $Output = Convert-StringToObject -InputString "Invoke-Cmdlet"
 
                 $Output | Should -Be "Invoke-Cmdlet"
             }

--- a/Tests/Unit/JeaRoleCapabilities.Tests.ps1
+++ b/Tests/Unit/JeaRoleCapabilities.Tests.ps1
@@ -20,7 +20,7 @@ Describe "Testing JeaRoleCapabilities" {
                 $Output.Count | Should -Be 2
                 $Output[0] | Should -BeOfType [Hashtable]
                 $Output[0].Name | Should -Be 'Invoke-Cmdlet'
-                ,$Output[0].Parameters | Should -BeOfType [Array]
+                $Output[0].Parameters.GetType().Name | Should -Be 'Object[]'
                 $Output[0].Parameters[0] | Should -BeOfType [Hashtable]
                 $Output[0].Parameters[1] | Should -BeOfType [Hashtable]
                 $Output[0].Parameters[0].Name | Should -Be 'Parameter1'
@@ -52,6 +52,21 @@ Describe "Testing JeaRoleCapabilities" {
                 $null = Convert-StringToObject -InputString "`$(New-Item File.txt),'Invoke-Cmdlet'"
 
                 Assert-MockCalled -CommandName New-Item -Times 0 -Scope It
+            }
+
+            It "Should return a single hashtable when passed one with multiple nested properties." {
+                $Output = Convert-StringToObject -InputString "@{Name = 'Invoke-Cmdlet'; Parameters = @{Name = 'Parameter1';Value = 'Value1'},@{Name = 'Parameter2'; Value = 'Value2'}}"
+
+                $Output | Should -BeOfType [Hashtable]
+                $Output.Parameters.GetType().Name | Should -Be 'Object[]'
+                $Output.Parameters[0].Name | Should -Be 'Parameter1'
+                $Output.Parameters[0].Value | Should -Be 'Value1'
+                $Output.Parameters[1].Name | Should -Be 'Parameter2'
+                $Output.Parameters[1].Value | Should -Be 'Value2'
+            }
+
+            It "Should write an error when not provided with a hashtable, string or combination" {
+                {$Output = Convert-StringToObject -InputString "`$(Get-Help)" -ErrorAction Stop} | Should -Throw
             }
         }
     }

--- a/Tests/Unit/JeaRoleCapabilities.Tests.ps1
+++ b/Tests/Unit/JeaRoleCapabilities.Tests.ps1
@@ -1,0 +1,43 @@
+$Module = Resolve-Path -Path "$PSScriptRoot\..\..\DSCClassResources\JeaRoleCapabilities\JeaRoleCapabilities.psd1"
+Import-Module $module -Force
+
+Describe "Testing JeaRoleCapabilities" {
+
+    InModuleScope JeaRoleCapabilities {
+        Context "Test string to hashtable conversion" {
+
+            It "Should return a string and a hashtable" {
+                $Output = Convert-StringToObject -InputString "'Invoke-Cmdlet1', @{ Name = 'Invoke-Cmdlet2'}"
+
+                $Output[0] | Should -Be 'Invoke-Cmdlet1'
+                $Output[1] | Should -BeOfType [Hashtable]
+                $Output[1].Name | Should -Be 'Invoke-Cmdlet2'
+            }
+
+            It "Should return 2 hashtables with one having a nested hashtable" {
+                $Output = Convert-StringToObject -InputString "@{Name = 'Invoke-Cmdlet'; Parameters = @{Name = 'Parameter1';Value = 'Value1'},@{Name = 'Parameter2'; Value = 'Value2'}},@{Name = 'Invoke-Cmdlet2'}"
+
+                $Output[0] | Should -BeOfType [Hashtable]
+                $Output[0].Name | Should -Be 'Invoke-Cmdlet'
+                ,$Output[0].Parameters | Should -BeOfType [Array]
+                $Output[0].Parameters[0] | Should -BeOfType [Hashtable]
+                $Output[0].Parameters[1] | Should -BeOfType [Hashtable]
+                $Output[0].Parameters[0].Name | Should -Be 'Parameter1'
+                $Output[1] | Should -BeOfType [Hashtable]
+                $Output[1].Name | Should -Be 'Invoke-Cmdlet2'
+            }
+
+            It "Should return a single string when passed only one cmdlet" {
+                $Output = Convert-StringToObject -InputString "'Invoke-Cmdlet'"
+
+                $Output | Should -Be "Invoke-Cmdlet"
+            }
+
+            It "Should return 2 strings when passed 2 comma separated strings in a single string" {
+                $Output = Convert-StringToObject -InputString "'Invoke-Cmdlet','Invoke-Cmdlet2'"
+
+                $Output | Should -Be 'Invoke-Cmdlet','Invoke-Cmdlet2'
+            }
+        }
+    }
+}

--- a/Tests/Unit/JeaRoleCapabilities.Tests.ps1
+++ b/Tests/Unit/JeaRoleCapabilities.Tests.ps1
@@ -17,6 +17,7 @@ Describe "Testing JeaRoleCapabilities" {
             It "Should return 2 hashtables with one having a nested hashtable" {
                 $Output = Convert-StringToObject -InputString "@{Name = 'Invoke-Cmdlet'; Parameters = @{Name = 'Parameter1';Value = 'Value1'},@{Name = 'Parameter2'; Value = 'Value2'}},@{Name = 'Invoke-Cmdlet2'}"
 
+                $Output.Count | Should -Be 2
                 $Output[0] | Should -BeOfType [Hashtable]
                 $Output[0].Name | Should -Be 'Invoke-Cmdlet'
                 ,$Output[0].Parameters | Should -BeOfType [Array]
@@ -33,10 +34,24 @@ Describe "Testing JeaRoleCapabilities" {
                 $Output | Should -Be "Invoke-Cmdlet"
             }
 
+            It "Should return a single hashtable when passed only one hashtable" {
+                $Output = Convert-StringToObject -InputString "@{Name = 'Invoke-Cmdlet'}"
+
+                $Output | Should -BeOfType [Hashtable]
+                $Output.Name | Should -Be 'Invoke-Cmdlet'
+            }
+
             It "Should return 2 strings when passed 2 comma separated strings in a single string" {
                 $Output = Convert-StringToObject -InputString "'Invoke-Cmdlet','Invoke-Cmdlet2'"
 
                 $Output | Should -Be 'Invoke-Cmdlet','Invoke-Cmdlet2'
+            }
+
+            It "Should not call New-Item when parsing the string input that contains an escaped subexpression" {
+                Mock -CommandName New-Item -MockWith {}
+                $null = Convert-StringToObject -InputString "`$(New-Item File.txt),'Invoke-Cmdlet'"
+
+                Assert-MockCalled -CommandName New-Item -Times 0 -Scope It
             }
         }
     }


### PR DESCRIPTION
Fixes the issues with #12 by using the ParseInput method on the Parser and then uses the AST to figure out what is a hashtable and what is a string.