### PR TITLE
Add condition to not create file if functions don't exist in exported

### DIFF
--- a/DSCClassResources/JeaRoleCapabilities/JeaRoleCapabilities.psm1
+++ b/DSCClassResources/JeaRoleCapabilities/JeaRoleCapabilities.psm1
@@ -145,16 +145,21 @@ class JeaRoleCapabilities {
                 $Parameters[$Parameter] = Convert-StringToObject -InputString $Parameters[$Parameter]
             }
 
+            $InvalidConfiguration = $false
+
             if ($Parameters.ContainsKey('FunctionDefinitions')) {
                 foreach ($FunctionDefName in $Parameters['FunctionDefinitions'].Name) {
                     if ($FunctionDefName -notin $Parameters['VisibleFunctions']) {
                         Write-Error -Message "Function defined but not visible to Role Configuration: $FunctionDefName"
+                        $InvalidConfiguration = $true
                     }
                 }
             }
-            $null = New-Item -Path $this.Path -ItemType File -Force
+            if (-not $InvalidConfiguration) {
+                $null = New-Item -Path $this.Path -ItemType File -Force
 
-            New-PSRoleCapabilityFile @Parameters
+                New-PSRoleCapabilityFile @Parameters
+            }
         }
         elseif ($this.Ensure -eq [Ensure]::Absent -and (Test-Path -Path $this.Path)) {
             Remove-Item -Path $this.Path -Confirm:$False


### PR DESCRIPTION
Integration tests are failing as the psrc is still being created even if the VisibleFunctions doesn't include all of the functions in the FunctionDefinitions. The existing error message is a good start but there should not be any file created in this scenario. This will add a check for that scenario and prevent files being created.